### PR TITLE
Small Bugfix and new sync feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,15 @@ It has lots of README files which guide you through the installation process.
 
 
 ## Equipment
-You will also need a ZWave USB stick. I tested this with the [The Aeotec Z-Stick Gen5](http://aeotec.com/z-wave-usb-stick). I think other zwave sticks will also work.
-Tested also with a Z-wave plus USB stick Model name: ZU1401EU.
+You will also need a ZWave USB stick.
+- Tested with the [The Aeotec Z-Stick Gen5](http://aeotec.com/z-wave-usb-stick).
+- Tested with a Z-wave plus USB stick Model name: ZU1401EU.
+I think other zwave sticks will also work.
 
-I used a Danfoss LC13 and a power plug for testing the devices.
-Implemented the door window sensor from devolo. This device has the contact sensor included, temperature sensor and lightness sensor.
+Tested Z-wave deviced
+- Danfoss LC13
+- a power plug
+- Door/Window sensor from Devolo. This device has a contact sensor, temperature sensor and lightness sensor included.
 
 ## What can this plugin do?
 - Control Devices
@@ -48,7 +52,7 @@ Example USB port for Windows '\\\\.\\COM3'
 ## Device settings in Pimatic
 I suggest using auto-discovery but if you want to add it manually:
 
-For a thermostat or a window contact sensor its possible to configure a sync timeout. This means that in case the z-wave device didnt update his values in this timeframe (configured in minutes) then the device is not synced anymore with pimatic. 
+For a thermostat or a window contact sensor its possible to configure a sync timeout. This means that in case the z-wave device didnt update his values in this timeframe (configured in minutes) then the device is not synced anymore with pimatic.
 
 ### thermostat device
 ```

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Example USB port for Windows '\\\\.\\COM3'
 ## Device settings in Pimatic
 I suggest using auto-discovery but if you want to add it manually:
 
+For a thermostat or a window contact sensor its possible to configure a sync timeout. This means that in case the z-wave device didnt update his values in this timeframe (configured in minutes) then the device is not synced anymore with pimatic. 
+
 ### thermostat device
 ```
     {
@@ -55,6 +57,7 @@ I suggest using auto-discovery but if you want to add it manually:
       "name": "ZWave Thermostat",
       "node": 4,
       "class": "ZwaveThermostat"
+      "syncTimeout": 45
     }
 ```
 
@@ -76,6 +79,7 @@ I suggest using auto-discovery but if you want to add it manually:
       "name": "ZWave WindowSensor",
       "node": 3,
       "class": "ZwaveWindowSensor"
+      "syncTimeout": 45
     }
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You will also need a ZWave USB stick.
 - Tested with a Z-wave plus USB stick Model name: ZU1401EU.
 I think other zwave sticks will also work.
 
-Tested Z-wave deviced
+Tested Z-Wave devices
 - Danfoss LC13
 - a power plug
 - Door/Window sensor from Devolo. This device has a contact sensor, temperature sensor and lightness sensor included.
@@ -28,7 +28,7 @@ Tested Z-wave deviced
 - Control Devices
     - Power switch _(class id: 32)_
     - Thermostat _(class id: 67)_
-    - Door/Window Sensor _(class id: 49)_
+    - Door/Window Sensor _(class id: 49)_ and _(class id: 48)_
       - contact and temperature support
 
 - Auto-discover ZWave devices

--- a/device-config-schema.coffee
+++ b/device-config-schema.coffee
@@ -33,22 +33,6 @@ module.exports = {
       node:
         description: "The zwave nodeid"
         type: "integer"
-        default: 0
-      contact:
-        description: "state of the contact"
-        type: "boolean"
-      synced:
-        description: "Pimatic and thermostat in sync"
-        type: "boolean"
-      battery:
-        description: "Battery status"
-        type: "string"
-        enum: ["ok", "low"]
-      temperature:
-        label: "Temperature"
-        description: "The temperature messarrured"
-        type: "number"
-        discrete: true
-        unit: "°C"
+        default: 0    
   }
 }

--- a/device-config-schema.coffee
+++ b/device-config-schema.coffee
@@ -16,6 +16,10 @@ module.exports = {
         description: "Show the valve position in the gui"
         type: "boolean"
         default: true
+      syncTimeout:
+        description: "After this timeout the sync status is reset to false, in minutes"
+        type: "integer"
+        default: 0
   }
   ZwavePowerSwitch: {
     title: "ZWave powerswitch options"
@@ -33,6 +37,10 @@ module.exports = {
       node:
         description: "The zwave nodeid"
         type: "integer"
-        default: 0    
+        default: 0
+      syncTimeout:
+        description: "After this timeout the sync status is reset to false, in minutes"
+        type: "integer"
+        default: 0
   }
 }

--- a/devices/zwave-thermostat.coffee
+++ b/devices/zwave-thermostat.coffee
@@ -34,8 +34,7 @@ module.exports = (env) ->
 
     timer: ->
       current_time = (new Date()).getTime()
-      time_since_last_sync =  current_time - @timestamp
-      console.log time_since_last_sync
+      time_since_last_sync =  current_time - @timestamp      
       if time_since_last_sync > 1800000
         @_setSynced(false)
 

--- a/devices/zwave-thermostat.coffee
+++ b/devices/zwave-thermostat.coffee
@@ -27,7 +27,21 @@ module.exports = (env) ->
       @_valve = lastState?.valve?.value or null
       @_lastSendTime = 0
 
+      @timestamp = (new Date()).getTime()
+
+      @setTimestampInterval()
       super()
+
+    timer: ->
+      current_time = (new Date()).getTime()
+      time_since_last_sync =  current_time - @timestamp
+      console.log time_since_last_sync
+      if time_since_last_sync > 1800000
+        @_setSynced(false)
+
+    setTimestampInterval: ->
+      cb = @timer.bind @
+      setInterval cb, 1800000
 
     _createResponseHandler: () ->
       return (response) =>
@@ -45,6 +59,7 @@ module.exports = (env) ->
             @_setSetpoint(parseInt(data.value))
             @_setValve(parseInt(data.value) / 28 * 100) #40 == 100%
             @_setSynced(true)
+            @timestamp = (new Date()).getTime()
 
           if data.class_id is 128
             @_base.debug "Update battery", data.value

--- a/devices/zwave-thermostat.coffee
+++ b/devices/zwave-thermostat.coffee
@@ -18,29 +18,31 @@ module.exports = (env) ->
 
       @_mode = "auto"
       @_setSynced(false)
-      
+
       @responseHandler = @_createResponseHandler()
       @plugin.protocolHandler.on 'response', @responseHandler
-      
+
       @_temperatureSetpoint = lastState?.temperatureSetpoint?.value or null
       @_battery = lastState?.battery?.value or "--"
       @_valve = lastState?.valve?.value or null
       @_lastSendTime = 0
+      @syncTimeoutTime = @config.syncTimeout * 1000 * 60
 
-      @timestamp = (new Date()).getTime()
+      if @syncTimeoutTime > 0
+        @timestamp = (new Date()).getTime()
+        @setTimestampInterval()
 
-      @setTimestampInterval()
       super()
 
     timer: ->
       current_time = (new Date()).getTime()
-      time_since_last_sync =  current_time - @timestamp      
-      if time_since_last_sync > 1800000
+      time_since_last_sync =  current_time - @timestamp
+      if time_since_last_sync > @syncTimeoutTime
         @_setSynced(false)
 
     setTimestampInterval: ->
       cb = @timer.bind @
-      setInterval cb, 1800000
+      setInterval cb, @syncTimeoutTime
 
     _createResponseHandler: () ->
       return (response) =>


### PR DESCRIPTION
Bugfix: You added inside the config the attributes of the window sensor. Only the node id is configurable.

New Feature: because the first status change set the z-wave device to synced always its impossible to get any unsynced states anymore.  I had some problems with my Danfos thermostat which is gone some time into an error mode on the device and didnt send any updated to pimatic about the current temperature set point. For pimatic the device was still synced. Now its possible to set for some device a syncronization timeout inside the config. This is optional and in case not set all is like before.